### PR TITLE
Added onUndock to the list of separation events

### DIFF
--- a/Source/FMRS_Core_Handler.cs
+++ b/Source/FMRS_Core_Handler.cs
@@ -72,6 +72,7 @@ namespace FMRS
                 if (_SAVE_Has_Launched)
                 {
                     GameEvents.onStageSeparation.Add(staging_routine);
+                    GameEvents.onUndock.Add (staging_routine);
                     GameEvents.onVesselCreate.Add(vessel_create_routine);
                 }
             }
@@ -86,6 +87,7 @@ namespace FMRS
         public void detach_handlers()
         {
             GameEvents.onStageSeparation.Remove(staging_routine);
+            GameEvents.onUndock.Remove(staging_routine);
             GameEvents.onLaunch.Remove(launch_routine);
             GameEvents.onCollision.Remove(crash_handler);
             GameEvents.onCrash.Remove(crash_handler);
@@ -149,6 +151,7 @@ namespace FMRS
                 _SAVE_Launched_At = Planetarium.GetUniversalTime();
                 fill_Vessels_list();
                 GameEvents.onStageSeparation.Add(staging_routine);
+                GameEvents.onUndock.Add(staging_routine);
                 GameEvents.onVesselCreate.Add(vessel_create_routine);
             }
 


### PR DESCRIPTION
Currently the only event recognized as separation is staging. However, staging is not always available - for instance I could not find a way for a docking port to become a stage after you dock two different ships.
Not sure about side-effects, but now undocking is detected as separation event as well.